### PR TITLE
Fix: Corrige temporada para 2024-25 e remove imports duplicados

### DIFF
--- a/app.py
+++ b/app.py
@@ -50,7 +50,7 @@ if menu == "Top 10":
             try:
                 with st.spinner("📊 Buscando estatísticas de times..."):
                     ranking = leaguedashteamstats.LeagueDashTeamStats(
-                        season="2025-26",
+                        season="2024-25",
                         season_type_all_star="Regular Season",
                         per_mode_detailed="PerGame"
                     ).get_data_frames()[0]

--- a/pages/times.py
+++ b/pages/times.py
@@ -4,12 +4,8 @@ import os
 import requests
 from datetime import datetime
 from nba_api.stats.static import teams
-from nba_api.stats.endpoints import teamdetails, commonteamroster, teamgamelog
+from nba_api.stats.endpoints import teamdetails, commonteamroster, teamgamelog, ScoreboardV2
 import base64
-from nba_api.stats.static import teams
-from nba_api.stats.endpoints import ScoreboardV2
-from datetime import datetime
-import pandas as pd
 
 # 🔥 Configuração da Página
 st.set_page_config(page_title="Detalhes da Equipe", layout="wide")
@@ -50,7 +46,7 @@ st.title(f"🏀 Detalhes da Equipe - {team_name}")
 # 🎯 Função para calcular estatísticas avançadas
 def calcular_estatisticas_avancadas(team_id):
     try:
-        jogos = teamgamelog.TeamGameLog(team_id=team_id, season="2025-26").get_data_frames()[0]
+        jogos = teamgamelog.TeamGameLog(team_id=team_id, season="2024-25").get_data_frames()[0]
         
         jogos_casa = jogos[jogos["MATCHUP"].str.contains("vs")]
         jogos_fora = jogos[jogos["MATCHUP"].str.contains("@")]

--- a/utils/api_utils.py
+++ b/utils/api_utils.py
@@ -12,7 +12,7 @@ def obter_elenco_time(team_id):
     return commonteamroster.CommonTeamRoster(team_id=team_id).get_data_frames()[0]
 
 def obter_ultimos_jogos(player_id):
-    return playergamelog.PlayerGameLog(player_id=player_id, season="2025-26").get_data_frames()[0]
+    return playergamelog.PlayerGameLog(player_id=player_id, season="2024-25").get_data_frames()[0]
 
 def obter_historico_por_temporadas(player_id, temporadas):
     historico = []


### PR DESCRIPTION
## Descrição
Corrige os seguintes erros no projeto NBA:

### 1. Temporada incorreta
A temporada 2025-26 ainda não tem dados disponíveis na API da NBA. Corrigido em:
- `app.py` (linha 53)
- `pages/times.py` (linha 53)
- `utils/api_utils.py` (linha 15)

### 2. Imports duplicados
Removidos imports duplicados em `pages/times.py`:
- `pandas` (importado 2x)
- `datetime` (importado 2x)
- `teams` de `nba_api.stats.static` (importado 2x)
- `ScoreboardV2` de `nba_api.stats.endpoints` (importado 2x)

## Alterações
- Alterada temporada de 2025-26 para 2024-25
- Removidos imports duplicados